### PR TITLE
Fix start script for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "prestart": "node prestart.mjs",
     "start": "next start",
     "lint": "next lint"
   },

--- a/prestart.mjs
+++ b/prestart.mjs
@@ -1,0 +1,12 @@
+import { existsSync } from 'fs'
+import { spawnSync } from 'child_process'
+
+if (!existsSync('.next')) {
+  console.log('No build found. Running "next build" first...')
+  const result = spawnSync('npm', ['run', 'build'], { stdio: 'inherit', shell: true })
+  if (result.status !== 0) {
+    console.error('Build failed. Exiting.')
+    process.exit(result.status ?? 1)
+  }
+}
+


### PR DESCRIPTION
## Summary
- ensure `npm start` builds the app if needed

## Testing
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_6841f7ddc938832fa4fc19b683e49185