### PR TITLE
Fix project creation button and modal handling in management page

### DIFF
--- a/app/management/page.tsx
+++ b/app/management/page.tsx
@@ -168,12 +168,6 @@ export default function ManagementPage() {
               </div>
             </div>
             <div className="flex items-center space-x-4">
-              {activeTab === "projects" && (
-                <Button onClick={handleCreateProject} className="flex items-center space-x-2">
-                  <Plus className="w-4 h-4" />
-                  <span>New Project</span>
-                </Button>
-              )}
               <SettingsButton />
             </div>
           </div>
@@ -192,10 +186,12 @@ export default function ManagementPage() {
               {isMobile ? (
                 <MobileProjectDashboard 
                   onProjectSelect={handleProjectSelect}
+                  onCreateProject={handleCreateProject}
                 />
               ) : (
                 <ProjectDashboard 
                   onProjectSelect={handleProjectSelect}
+                  onCreateProject={handleCreateProject}
                 />
               )}
             </TabsContent>

--- a/components/project-dashboard.tsx
+++ b/components/project-dashboard.tsx
@@ -164,9 +164,6 @@ export default function ProjectDashboard({
   const handleCreateProject = () => {
     if (onCreateProject) {
       onCreateProject()
-    } else {
-      // Project creation will be handled within the tab system
-      console.log('Create new project')
     }
   }
 
@@ -304,7 +301,7 @@ export default function ProjectDashboard({
               Templates
             </Button> */}
             <Button 
-              onClick={() => onCreateProject()}
+              onClick={handleCreateProject}
               className="mb-6"
               size="lg"
             >


### PR DESCRIPTION
## Summary
- Removes redundant "New Project" button from the management page header
- Passes `onCreateProject` handler correctly to both mobile and desktop project dashboard components
- Updates project dashboard to use internal `handleCreateProject` method for button click, ensuring proper callback invocation

## Changes

### Management Page
- Removed the "New Project" button from the projects tab header to avoid duplication
- Added `onCreateProject` prop to both `MobileProjectDashboard` and `ProjectDashboard` components

### Project Dashboard Component
- Refactored project creation button to use internal `handleCreateProject` method
- Removed unnecessary else block with console log in `handleCreateProject` to clean up code

## Test plan
- [x] Verify that clicking the project creation button in the dashboard triggers the project creation flow
- [x] Confirm no duplicate "New Project" buttons appear in the management page header
- [x] Test project creation flow on both mobile and desktop views
- [x] Ensure no console warnings or errors related to project creation callbacks

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9e1d9b57-1b3a-4ca0-9319-9cf84d18d8ee